### PR TITLE
Add admin authorization to users show endpoint

### DIFF
--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -1,6 +1,6 @@
 class Api::V2::UsersController < ApplicationController
   before_action :authenticate_user!
-  before_action :require_admin, only: [:index, :create, :destroy]
+  before_action :require_admin, only: [:index, :create, :destroy, :show]
   before_action :set_user, only: [:show, :update, :destroy, :remove_image]
   before_action :require_self_or_admin, only: :update
 


### PR DESCRIPTION
## Summary

This PR adds admin authorization to the users show endpoint to support the admin-aware users profile page feature. The change ensures that only admin users can view user profiles via the API.

## Changes

### Backend Security Enhancement
- **`users_controller.rb`**: Added `:show` to the `require_admin` before_action
- **Authorization**: Users show endpoint now requires admin permissions
- **API Security**: Prevents non-admin users from accessing user profile data

## Security Impact

### Before
- Users show endpoint was accessible to authenticated users
- Potential unauthorized access to user profile information

### After  
- ✅ Only admin users can access user profile data via API
- ✅ Consistent authorization across all user management endpoints
- ✅ Aligns with frontend access control implementation

## Related Changes

This backend security enhancement supports the frontend admin-aware users profile page feature:
- Frontend already implements admin-only access control
- Backend now enforces the same security restrictions
- Complete end-to-end security for user profile management

## Testing

- ✅ Verified admin users can access user profiles
- ✅ Confirmed non-admin users receive 403 Forbidden responses
- ✅ End-to-end tests validate complete access control flow

## Breaking Changes

**Potential Impact**: Non-admin users who previously had access to user profile API endpoints will now receive 403 Forbidden responses. This is intentional security hardening.

## Migration Notes

No database migrations required. This is a pure authorization enhancement.

🤖 Generated with [Claude Code](https://claude.ai/code)