### PR TITLE
Add Master Campaign character copying to campaign seeding

### DIFF
--- a/spec/services/campaign_seeder_integration_spec.rb
+++ b/spec/services/campaign_seeder_integration_spec.rb
@@ -1,0 +1,285 @@
+require 'rails_helper'
+
+RSpec.describe 'Campaign Seeding Integration', type: :integration do
+  let!(:gamemaster) do
+    User.create!(
+      email: 'gm@example.com',
+      first_name: 'Game',
+      last_name: 'Master',
+      password: 'TestPass123!',
+      gamemaster: true
+    )
+  end
+  
+  let!(:player) do
+    User.create!(
+      email: 'player@example.com',
+      first_name: 'Player',
+      last_name: 'One',
+      password: 'TestPass123!',
+      gamemaster: false
+    )
+  end
+  
+  # Create Master Template Campaign with template characters
+  let!(:master_template) do
+    Campaign.create!(
+      name: 'Master Template Campaign',
+      is_master_template: true,
+      user: gamemaster
+    )
+  end
+  
+  let!(:template_characters) do
+    [
+      Character.create!(
+        name: 'Martial Artist Template',
+        is_template: true,
+        action_values: { "Type" => "PC", "Archetype" => "Martial Artist" },
+        campaign: master_template,
+        user: gamemaster
+      ),
+      Character.create!(
+        name: 'Gunslinger Template',
+        is_template: true,
+        action_values: { "Type" => "PC", "Archetype" => "Gunslinger" },
+        campaign: master_template,
+        user: gamemaster
+      )
+    ]
+  end
+  
+  # Create Master Campaign with non-template characters
+  let!(:master_campaign) do
+    Campaign.create!(
+      name: 'Master Campaign',
+      user: gamemaster
+    )
+  end
+  
+  let!(:master_characters) do
+    [
+      Character.create!(
+        name: 'The Dragon Boss',
+        is_template: false,
+        action_values: { 
+          "Type" => "Boss",
+          "Martial Arts" => 15,
+          "Defense" => 13,
+          "Toughness" => 8
+        },
+        description: { "Background" => "Ancient martial arts master" },
+        campaign: master_campaign,
+        user: gamemaster
+      ),
+      Character.create!(
+        name: 'Cyber Ninja',
+        is_template: false,
+        action_values: { 
+          "Type" => "Featured Foe",
+          "Martial Arts" => 12,
+          "Scroungetech" => 10
+        },
+        campaign: master_campaign,
+        user: gamemaster
+      ),
+      Character.create!(
+        name: 'Street Thug',
+        is_template: false,
+        action_values: { "Type" => "Mook" },
+        campaign: master_campaign,
+        user: gamemaster
+      ),
+      Character.create!(
+        name: 'Detective Lee',
+        is_template: false,
+        action_values: { "Type" => "Ally" },
+        campaign: master_campaign,
+        user: gamemaster
+      )
+    ]
+  end
+  
+  # Add some template characters to Master Campaign that should NOT be copied
+  let!(:master_campaign_templates) do
+    Character.create!(
+      name: 'Should Not Be Copied Template',
+      is_template: true,
+      action_values: { "Type" => "PC" },
+      campaign: master_campaign,
+      user: gamemaster
+    )
+  end
+  
+  describe 'Complete campaign creation and seeding flow' do
+    context 'when creating a new campaign as gamemaster' do
+      let(:new_campaign) do
+        Campaign.create!(
+          name: 'My New Campaign',
+          user: gamemaster
+        )
+      end
+      
+      it 'seeds campaign with both template and Master Campaign characters' do
+        expect {
+          result = CampaignSeederService.seed_campaign(new_campaign)
+          expect(result).to be true
+        }.to change { new_campaign.characters.count }.from(0).to(6)
+        # 2 templates from master_template + 4 non-templates from Master Campaign
+        
+        new_campaign.reload
+        character_names = new_campaign.characters.pluck(:name)
+        
+        # Check template characters were copied
+        expect(character_names).to include('Martial Artist Template')
+        expect(character_names).to include('Gunslinger Template')
+        
+        # Check Master Campaign non-template characters were copied
+        expect(character_names).to include('The Dragon Boss')
+        expect(character_names).to include('Cyber Ninja')
+        expect(character_names).to include('Street Thug')
+        expect(character_names).to include('Detective Lee')
+        
+        # Check template from Master Campaign was NOT copied
+        expect(character_names).not_to include('Should Not Be Copied Template')
+      end
+      
+      it 'preserves character attributes when copying' do
+        CampaignSeederService.seed_campaign(new_campaign)
+        
+        # Check Boss character attributes
+        boss = new_campaign.characters.find_by(name: 'The Dragon Boss')
+        expect(boss).not_to be_nil
+        expect(boss.action_values["Type"]).to eq("Boss")
+        expect(boss.action_values["Martial Arts"]).to eq(15)
+        expect(boss.action_values["Defense"]).to eq(13)
+        expect(boss.description["Background"]).to eq("Ancient martial arts master")
+        
+        # Check Featured Foe attributes
+        ninja = new_campaign.characters.find_by(name: 'Cyber Ninja')
+        expect(ninja.action_values["Type"]).to eq("Featured Foe")
+        expect(ninja.action_values["Scroungetech"]).to eq(10)
+      end
+      
+      it 'marks campaign as seeded after completion' do
+        expect(new_campaign.seeded_at).to be_nil
+        
+        CampaignSeederService.seed_campaign(new_campaign)
+        new_campaign.reload
+        
+        expect(new_campaign.seeded_at).to be_present
+      end
+      
+      it 'does not reseed an already seeded campaign' do
+        # First seeding
+        CampaignSeederService.seed_campaign(new_campaign)
+        first_count = new_campaign.characters.count
+        first_seeded_at = new_campaign.reload.seeded_at
+        
+        # Attempt second seeding
+        result = CampaignSeederService.seed_campaign(new_campaign)
+        
+        expect(result).to be false
+        expect(new_campaign.characters.count).to eq(first_count)
+        expect(new_campaign.reload.seeded_at).to eq(first_seeded_at)
+      end
+    end
+    
+    context 'when Master Campaign has many characters' do
+      before do
+        # Add 20 more characters to Master Campaign
+        20.times do |i|
+          Character.create!(
+            name: "Enemy #{i}",
+            is_template: false,
+            action_values: { "Type" => "Featured Foe" },
+            campaign: master_campaign,
+            user: gamemaster
+          )
+        end
+      end
+      
+      it 'copies all non-template characters efficiently' do
+        new_campaign = Campaign.create!(name: 'Large Campaign', user: gamemaster)
+        
+        expect {
+          CampaignSeederService.seed_campaign(new_campaign)
+        }.to change { new_campaign.characters.count }.from(0).to(26)
+        # 2 templates + 4 original + 20 additional = 26
+      end
+    end
+    
+    context 'when Master Campaign is empty' do
+      before do
+        master_characters.each(&:destroy)
+        master_campaign_templates.destroy
+      end
+      
+      it 'still seeds with template characters' do
+        new_campaign = Campaign.create!(name: 'Campaign Without Master', user: gamemaster)
+        
+        expect {
+          CampaignSeederService.seed_campaign(new_campaign)
+        }.to change { new_campaign.characters.count }.from(0).to(2)
+        # Only the 2 template characters
+        
+        character_names = new_campaign.characters.pluck(:name)
+        expect(character_names).to include('Martial Artist Template')
+        expect(character_names).to include('Gunslinger Template')
+      end
+    end
+    
+    context 'when Master Campaign does not exist' do
+      before do
+        master_characters.each(&:destroy)
+        master_campaign_templates.destroy
+        master_campaign.destroy
+      end
+      
+      it 'still completes seeding with just templates' do
+        new_campaign = Campaign.create!(name: 'Campaign No Master', user: gamemaster)
+        
+        result = CampaignSeederService.seed_campaign(new_campaign)
+        expect(result).to be true
+        
+        expect(new_campaign.characters.count).to eq(2)
+        expect(new_campaign.reload.seeded_at).to be_present
+      end
+    end
+    
+    context 'when neither Master Template nor Master Campaign exist' do
+      before do
+        template_characters.each(&:destroy)
+        master_template.destroy
+        master_characters.each(&:destroy)
+        master_campaign_templates.destroy
+        master_campaign.destroy
+      end
+      
+      it 'returns false and does not mark as seeded' do
+        new_campaign = Campaign.create!(name: 'Campaign No Seeds', user: gamemaster)
+        
+        result = CampaignSeederService.seed_campaign(new_campaign)
+        expect(result).to be false
+        
+        expect(new_campaign.characters.count).to eq(0)
+        expect(new_campaign.reload.seeded_at).to be_nil
+      end
+    end
+  end
+  
+  describe 'Character ownership and associations' do
+    let(:new_campaign) do
+      Campaign.create!(name: 'Association Test Campaign', user: gamemaster)
+    end
+    
+    it 'sets correct user ownership for all copied characters' do
+      CampaignSeederService.seed_campaign(new_campaign)
+      
+      new_campaign.characters.each do |character|
+        expect(character.user).to eq(gamemaster)
+        expect(character.campaign).to eq(new_campaign)
+      end
+    end
+  end
+end

--- a/spec/services/campaign_seeder_service_spec.rb
+++ b/spec/services/campaign_seeder_service_spec.rb
@@ -82,6 +82,43 @@ RSpec.describe CampaignSeederService, type: :service do
     )
   end
   
+  # Master Campaign for non-template character copying
+  let!(:master_campaign) do
+    Campaign.create!(
+      name: 'Master Campaign',
+      user: gamemaster
+    )
+  end
+  
+  let!(:master_npc) do
+    Character.create!(
+      name: 'Master NPC Boss',
+      is_template: false,
+      action_values: { "Type" => "Boss" },
+      campaign: master_campaign,
+      user: gamemaster
+    )
+  end
+  
+  let!(:master_featured_foe) do
+    Character.create!(
+      name: 'Master Featured Foe',
+      is_template: false,
+      action_values: { "Type" => "Featured Foe" },
+      campaign: master_campaign,
+      user: gamemaster
+    )
+  end
+  
+  let!(:master_template_char) do
+    Character.create!(
+      name: 'Should Not Be Copied',
+      is_template: true,
+      campaign: master_campaign,
+      user: gamemaster
+    )
+  end
+  
   let(:new_campaign) do
     Campaign.create!(name: 'New Campaign', user: gamemaster)
   end
@@ -91,7 +128,7 @@ RSpec.describe CampaignSeederService, type: :service do
       it 'seeds the campaign with template characters' do
         expect {
           CampaignSeederService.seed_campaign(new_campaign)
-        }.to change { new_campaign.characters.count }.by(1)
+        }.to change { new_campaign.characters.count }.by(3) # 1 template + 2 from Master Campaign
       end
 
       it 'marks the campaign as seeded' do
@@ -106,8 +143,9 @@ RSpec.describe CampaignSeederService, type: :service do
       it 'duplicates template character attributes correctly' do
         CampaignSeederService.seed_campaign(new_campaign)
         
-        duplicated_character = new_campaign.characters.first
-        expect(duplicated_character.name).to include('Martial Artist Template')
+        # Find the template character specifically
+        duplicated_character = new_campaign.characters.find { |c| c.name.include?('Martial Artist Template') }
+        expect(duplicated_character).not_to be_nil
         expect(duplicated_character.is_template).to be true
         expect(duplicated_character.campaign).to eq(new_campaign)
       end
@@ -115,6 +153,137 @@ RSpec.describe CampaignSeederService, type: :service do
       it 'returns true on success' do
         result = CampaignSeederService.seed_campaign(new_campaign)
         expect(result).to be true
+      end
+      
+      context 'with Master Campaign present' do
+        it 'copies non-template characters from Master Campaign' do
+          CampaignSeederService.seed_campaign(new_campaign)
+          
+          character_names = new_campaign.characters.map(&:name)
+          expect(character_names).to include('Master NPC Boss')
+          expect(character_names).to include('Master Featured Foe')
+        end
+        
+        it 'does not copy template characters from Master Campaign' do
+          CampaignSeederService.seed_campaign(new_campaign)
+          
+          character_names = new_campaign.characters.map(&:name)
+          expect(character_names).not_to include('Should Not Be Copied')
+        end
+        
+        it 'copies both master template and Master Campaign characters' do
+          expect {
+            CampaignSeederService.seed_campaign(new_campaign)
+          }.to change { new_campaign.characters.count }.by(3)
+          # 1 from master template + 2 non-template from Master Campaign
+        end
+        
+        it 'preserves character types when copying from Master Campaign' do
+          CampaignSeederService.seed_campaign(new_campaign)
+          
+          boss = new_campaign.characters.find_by(name: 'Master NPC Boss')
+          foe = new_campaign.characters.find_by(name: 'Master Featured Foe')
+          
+          expect(boss.action_values["Type"]).to eq('Boss')
+          expect(foe.action_values["Type"]).to eq('Featured Foe')
+        end
+      end
+      
+      context 'when Master Campaign does not exist' do
+        before do
+          master_npc.destroy
+          master_featured_foe.destroy
+          master_template_char.destroy
+          master_campaign.destroy
+        end
+        
+        it 'still seeds with template characters' do
+          expect {
+            CampaignSeederService.seed_campaign(new_campaign)
+          }.to change { new_campaign.characters.count }.by(1)
+        end
+        
+        it 'logs warning about missing Master Campaign' do
+          allow(Rails.logger).to receive(:info)
+          expect(Rails.logger).to receive(:info).with("No Master Campaign found, skipping non-template character copying")
+          CampaignSeederService.seed_campaign(new_campaign)
+        end
+      end
+      
+      context 'when character duplication fails' do
+        before do
+          # Allow template character duplication to work normally
+          allow(CharacterDuplicatorService).to receive(:duplicate_character)
+            .with(template_character, gamemaster, new_campaign)
+            .and_call_original
+          # Stub failure for master_npc
+          allow(CharacterDuplicatorService).to receive(:duplicate_character)
+            .with(master_npc, gamemaster, new_campaign)
+            .and_return(double(save: false, errors: double(full_messages: ['Validation failed'])))
+          # Allow master_featured_foe to work normally
+          allow(CharacterDuplicatorService).to receive(:duplicate_character)
+            .with(master_featured_foe, gamemaster, new_campaign)
+            .and_call_original
+        end
+        
+        it 'continues copying other characters' do
+          allow(Rails.logger).to receive(:error)
+          allow(Rails.logger).to receive(:info)
+          
+          expect {
+            CampaignSeederService.seed_campaign(new_campaign)
+          }.to change { new_campaign.characters.count }.by(2)
+          # Should copy: 1 template + 1 successful non-template (featured foe)
+        end
+        
+        it 'logs error for failed character' do
+          allow(Rails.logger).to receive(:info)
+          expect(Rails.logger).to receive(:error).with(/Failed to copy character Master NPC Boss from Master Campaign: Validation failed/)
+          
+          CampaignSeederService.seed_campaign(new_campaign)
+        end
+        
+        it 'still returns true if template seeding succeeded' do
+          allow(Rails.logger).to receive(:error)
+          allow(Rails.logger).to receive(:info)
+          
+          result = CampaignSeederService.seed_campaign(new_campaign)
+          expect(result).to be true
+        end
+      end
+      
+      context 'when character duplication raises exception' do
+        before do
+          # Allow template character duplication to work normally
+          allow(CharacterDuplicatorService).to receive(:duplicate_character)
+            .with(template_character, gamemaster, new_campaign)
+            .and_call_original
+          # Raise exception for master_npc
+          allow(CharacterDuplicatorService).to receive(:duplicate_character)
+            .with(master_npc, gamemaster, new_campaign)
+            .and_raise(StandardError, 'Database connection error')
+          # Allow master_featured_foe to work normally
+          allow(CharacterDuplicatorService).to receive(:duplicate_character)
+            .with(master_featured_foe, gamemaster, new_campaign)
+            .and_call_original
+        end
+        
+        it 'catches exception and continues with other characters' do
+          allow(Rails.logger).to receive(:error)
+          allow(Rails.logger).to receive(:info)
+          
+          expect {
+            CampaignSeederService.seed_campaign(new_campaign)
+          }.to change { new_campaign.characters.count }.by(2)
+          # Should copy: 1 template + 1 successful non-template (featured foe)
+        end
+        
+        it 'logs exception details' do
+          allow(Rails.logger).to receive(:info)
+          expect(Rails.logger).to receive(:error).with(/Error copying character Master NPC Boss from Master Campaign: Database connection error/)
+          
+          CampaignSeederService.seed_campaign(new_campaign)
+        end
       end
     end
 
@@ -171,7 +340,7 @@ RSpec.describe CampaignSeederService, type: :service do
       it 'copies all content types from source to target campaign' do
         expect {
           CampaignSeederService.copy_campaign_content(source_campaign, target_campaign)
-        }.to change { target_campaign.characters.count }.by(1)
+        }.to change { target_campaign.characters.count }.by(3) # 1 from source + 2 from Master Campaign
          .and change { target_campaign.vehicles.count }.by(1)
          .and change { target_campaign.schticks.count }.by(1)
          .and change { target_campaign.weapons.count }.by(1)
@@ -206,8 +375,9 @@ RSpec.describe CampaignSeederService, type: :service do
       it 'copies character with correct attributes' do
         CampaignSeederService.copy_campaign_content(source_campaign, target_campaign)
         
-        copied_character = target_campaign.characters.first
-        expect(copied_character.name).to include('Source Character')
+        # Find the source character specifically (not Master Campaign characters)
+        copied_character = target_campaign.characters.find { |c| c.name.include?('Source Character') }
+        expect(copied_character).not_to be_nil
         expect(copied_character.campaign).to eq(target_campaign)
         expect(copied_character.user).to eq(gamemaster)
       end
@@ -250,11 +420,11 @@ RSpec.describe CampaignSeederService, type: :service do
         Campaign.create!(name: 'Empty Campaign', user: gamemaster)
       end
 
-      it 'still returns true but copies nothing' do
+      it 'still returns true but copies Master Campaign characters' do
         expect {
           result = CampaignSeederService.copy_campaign_content(empty_campaign, target_campaign)
           expect(result).to be true
-        }.not_to change { target_campaign.characters.count + target_campaign.vehicles.count }
+        }.to change { target_campaign.characters.count }.by(2) # Only Master Campaign characters
       end
     end
   end


### PR DESCRIPTION
## Summary

This PR enhances the CampaignSeederService to automatically copy all non-template characters from the Master Campaign when creating new campaigns, providing gamemasters with ready-to-use NPCs and enemies immediately upon campaign creation.

## Changes

- **CampaignSeederService Enhancement**
  - Added `copy_master_campaign_characters` method to find and copy non-template characters
  - Integrated copying into existing transaction for data consistency
  - Robust error handling ensures individual failures don't break the process
  - Detailed logging for debugging and monitoring

## Testing

- ✅ 30 unit tests in `campaign_seeder_service_spec.rb` 
- ✅ 9 integration tests in `campaign_seeder_integration_spec.rb`
- ✅ All 85 service tests passing
- ✅ Full test suite (1510 examples) passing

## Test Coverage

- Normal operation with both master template and Master Campaign
- Missing Master Campaign (graceful fallback)
- Character duplication failures (continues with other characters)
- Exception handling during duplication
- Large-scale copying (20+ characters)
- Empty Master Campaign scenarios
- Character attribute preservation
- Transaction integrity

## Benefits

- Gamemasters receive both template characters AND ready-to-use NPCs/enemies
- Significantly reduces campaign setup time
- Preserves all character attributes, types, and descriptions
- Graceful fallback when Master Campaign doesn't exist
- No duplication of template characters

## Implementation Details

The service now:
1. Copies template characters from the campaign marked with `is_master_template: true`
2. Then copies all non-template characters from the campaign named "Master Campaign"
3. Uses existing `CharacterDuplicatorService` for consistency
4. Handles errors gracefully to ensure partial failures don't break campaign creation

🤖 Generated with [Claude Code](https://claude.ai/code)