### PR TITLE
Add CircleCI configuration for automated testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,125 @@
+version: 2.1
+
+orbs:
+  ruby: circleci/ruby@2.1.0
+
+jobs:
+  test:
+    docker:
+      # Primary container image
+      - image: cimg/ruby:3.2.2
+        environment:
+          RAILS_ENV: test
+          POSTGRES_HOST: 127.0.0.1
+          POSTGRES_USER: circleci
+          POSTGRES_PASSWORD: ""
+          POSTGRES_DB: shot_server_test
+      
+      # PostgreSQL database
+      - image: cimg/postgres:15.0
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_DB: shot_server_test
+          POSTGRES_PASSWORD: ""
+          POSTGRES_HOST_AUTH_METHOD: trust
+      
+      # Redis
+      - image: cimg/redis:7.0
+    
+    working_directory: ~/repo
+    
+    steps:
+      - checkout
+      
+      # Install system dependencies
+      - run:
+          name: Install system dependencies
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y libpq-dev postgresql-client
+      
+      # Cache Ruby gems
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "Gemfile.lock" }}
+            - v1-dependencies-
+      
+      # Install Ruby dependencies
+      - run:
+          name: Install dependencies
+          command: |
+            gem install bundler
+            bundle config set --local path 'vendor/bundle'
+            bundle install --jobs=4 --retry=3
+      
+      # Save cache
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+      
+      # Wait for database
+      - run:
+          name: Wait for database
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      
+      # Database setup
+      - run:
+          name: Database setup
+          command: |
+            bundle exec rails db:create
+            bundle exec rails db:schema:load
+      
+      # Run RSpec tests
+      - run:
+          name: Run tests
+          command: |
+            mkdir /tmp/test-results
+            bundle exec rspec --format progress \
+                            --format RspecJunitFormatter \
+                            --out /tmp/test-results/rspec.xml \
+                            --format progress
+      
+      # Store test results for CircleCI
+      - store_test_results:
+          path: /tmp/test-results
+      
+      # Store test artifacts
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results
+
+  lint:
+    docker:
+      - image: cimg/ruby:3.2.2
+    
+    working_directory: ~/repo
+    
+    steps:
+      - checkout
+      
+      # Cache Ruby gems
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "Gemfile.lock" }}
+            - v1-dependencies-
+      
+      # Install Ruby dependencies
+      - run:
+          name: Install dependencies
+          command: |
+            gem install bundler
+            bundle config set --local path 'vendor/bundle'
+            bundle install --jobs=4 --retry=3
+      
+      # Run RuboCop
+      - run:
+          name: Run RuboCop
+          command: bundle exec rubocop
+
+workflows:
+  version: 2
+  test_and_lint:
+    jobs:
+      - test
+      - lint

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem "rspec-rails"
+  gem "rspec_junit_formatter"  # For CircleCI test reporting
   gem "database_cleaner-active_record"
   gem "letter_opener"
   gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,6 +371,8 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.4)
+    rspec_junit_formatter (0.6.0)
+      rspec-core (>= 2, < 4, != 2.12.0)
     ruby-vips (2.2.4)
       ffi (~> 1.12)
       logger
@@ -441,6 +443,7 @@ DEPENDENCIES
   redis (~> 4.0)
   reverse_markdown
   rspec-rails
+  rspec_junit_formatter
   ruby-vips
   sidekiq (~> 7.0)
   tzinfo-data


### PR DESCRIPTION
## Summary
- Add CircleCI configuration for continuous integration
- Configure automated testing pipeline for Rails backend
- Add rspec_junit_formatter for test result reporting

## Changes
- Created `.circleci/config.yml` with test and lint jobs
- Added `rspec_junit_formatter` gem for CircleCI test reporting
- Configured PostgreSQL and Redis services for test environment
- RSpec test execution with JUnit format output
- RuboCop linting job (ready when RuboCop is configured)
- Ruby gem caching for faster CI runs

## Test Plan
- [ ] CircleCI successfully runs on this PR
- [ ] RSpec tests execute with PostgreSQL and Redis
- [ ] Test results are properly reported in JUnit format
- [ ] Gem caching works correctly

This PR adds automated testing infrastructure to ensure code quality and catch regressions early in the development process.

🤖 Generated with [Claude Code](https://claude.ai/code)