### PR TITLE
Fix campaign seeding: eliminate broadcast spam and fix image/prerequisite duplication

### DIFF
--- a/app/models/concerns/broadcastable.rb
+++ b/app/models/concerns/broadcastable.rb
@@ -9,10 +9,12 @@ module Broadcastable
   end
 
   def broadcast_campaign_update
+    return if Thread.current[:disable_broadcasts]
     BroadcastCampaignUpdateJob.perform_later(self.class.name, id)
   end
 
   def broadcast_reload
+    return if Thread.current[:disable_broadcasts]
     Rails.logger.info "🔄 Broadcastable: #{self.class.name} (ID: #{id}) triggering reload broadcast for campaign_id: #{self.campaign_id}"
     BroadcastCampaignReloadJob.perform_later(self.class.name, self.campaign_id)
   end


### PR DESCRIPTION
## Summary
- Eliminates excessive WebSocket broadcast spam during campaign seeding (644+ events reduced to minimal)
- Fixes ImageKit image duplication failures that were preventing seeding completion
- Resolves schtick prerequisite linking issues that weren't maintaining relationships
- Fixes character name uniqueness validation that was causing seeding rollbacks

## Changes Made
- **app/services/campaign_seeder_service.rb**: Added broadcast suppression with Thread.current[:disable_broadcasts] flag
- **app/models/concerns/broadcastable.rb**: Check broadcast flag before sending WebSocket events
- **app/services/character_duplicator_service.rb**: Fixed name uniqueness validation and ImageKit download handling
- **app/services/schtick_duplicator_service.rb**: Fixed prerequisite linking and image duplication
- **app/services/weapon_duplicator_service.rb**: Improved ImageKit image handling
- **app/services/vehicle_duplicator_service.rb**: Fixed image duplication issues

## Problem Solved
Campaign seeding was failing due to:
1. **Performance**: 644+ WebSocket broadcast events during seeding causing significant slowdown
2. **ImageKit failures**: Download format issues preventing image duplication
3. **Prerequisite corruption**: Schtick prerequisites weren't being properly linked
4. **Name conflicts**: Character uniqueness validation causing transaction rollbacks

## Testing
- Successfully tested seeding Master Campaign with 644 schticks, 189 weapons, and multiple characters
- Verified broadcast suppression works correctly during bulk operations
- Confirmed all duplicated entities maintain proper relationships and images

## Impact
- Resolves campaign seeding failures that were blocking new campaign creation
- Eliminates performance issues during seeding operations
- Ensures data integrity for prerequisites and image relationships

🤖 Generated with [Claude Code](https://claude.ai/code)