### PR TITLE
Add backend support for entity active field toggle

### DIFF
--- a/app/controllers/api/v2/factions_controller.rb
+++ b/app/controllers/api/v2/factions_controller.rb
@@ -115,7 +115,7 @@ class Api::V2::FactionsController < ApplicationController
       faction_data = faction_params.to_h.symbolize_keys
     end
 
-    faction_data = faction_data.slice(:name, :description, :character_ids, :party_ids, :site_ids, :juncture_ids, :vehicle_ids)
+    faction_data = faction_data.slice(:name, :description, :character_ids, :party_ids, :site_ids, :juncture_ids, :vehicle_ids, :active)
 
     @faction = current_campaign.factions.new(faction_data)
 
@@ -147,7 +147,7 @@ class Api::V2::FactionsController < ApplicationController
     else
       faction_data = faction_params.to_h.symbolize_keys
     end
-    faction_data = faction_data.slice(:name, :description, :character_ids, :party_ids, :site_ids, :juncture_ids, :vehicle_ids)
+    faction_data = faction_data.slice(:name, :description, :character_ids, :party_ids, :site_ids, :juncture_ids, :vehicle_ids, :active)
 
     # Handle image attachment if present
     if params[:image].present?
@@ -205,7 +205,7 @@ class Api::V2::FactionsController < ApplicationController
   end
 
   def faction_params
-    params.require(:faction).permit(:name, :description, :image, character_ids: [], party_ids: [], site_ids: [], juncture_ids: [], vehicle_ids: [])
+    params.require(:faction).permit(:name, :description, :active, :image, character_ids: [], party_ids: [], site_ids: [], juncture_ids: [], vehicle_ids: [])
   end
 
   def sort_order

--- a/app/controllers/api/v2/schticks_controller.rb
+++ b/app/controllers/api/v2/schticks_controller.rb
@@ -236,7 +236,7 @@ class Api::V2::SchticksController < ApplicationController
     else
       schtick_data = schtick_params.to_h.symbolize_keys
     end
-    schtick_data = schtick_data.slice(:name, :description, :category, :path, :color, :prerequisite_id)
+    schtick_data = schtick_data.slice(:name, :description, :category, :path, :color, :prerequisite_id, :active)
 
     # Handle image attachment if present
     if params[:image].present?
@@ -289,7 +289,7 @@ class Api::V2::SchticksController < ApplicationController
   end
 
   def schtick_params
-    params.require(:schtick).permit(:name, :description, :category, :path, :color, :image_url, :prerequisite_id)
+    params.require(:schtick).permit(:name, :description, :category, :path, :color, :image_url, :prerequisite_id, :active)
   end
 
   def sort_order

--- a/app/controllers/api/v2/weapons_controller.rb
+++ b/app/controllers/api/v2/weapons_controller.rb
@@ -187,7 +187,7 @@ class Api::V2::WeaponsController < ApplicationController
       weapon_data = weapon_params.to_h.symbolize_keys
     end
 
-    weapon_data.slice(:name, :description, :active)
+    weapon_data = weapon_data.slice(:name, :description, :damage, :concealment, :reload_value, :juncture, :mook_bonus, :category, :kachunk, :active)
 
     @weapon = current_campaign.weapons.new(weapon_data)
 
@@ -217,7 +217,7 @@ class Api::V2::WeaponsController < ApplicationController
     else
       weapon_data = weapon_params.to_h.symbolize_keys
     end
-    weapon_data = weapon_data.slice(:name, :description, :damage, :concealment, :reload_value, :juncture, :mook_bonus, :category, :kachunk)
+    weapon_data = weapon_data.slice(:name, :description, :damage, :concealment, :reload_value, :juncture, :mook_bonus, :category, :kachunk, :active)
 
     # Handle image attachment if present
     if params[:image].present?
@@ -284,7 +284,7 @@ class Api::V2::WeaponsController < ApplicationController
   def weapon_params
     params.require(:weapon).permit(:name,
      :description, :damage, :concealment, :reload_value, :juncture, :mook_bonus, :category,
-     :kachunk, :image)
+     :kachunk, :active, :image)
   end
 
   def pagination_meta(object)

--- a/app/serializers/schtick_serializer.rb
+++ b/app/serializers/schtick_serializer.rb
@@ -1,5 +1,5 @@
 class SchtickSerializer < ActiveModel::Serializer
-  attributes :id, :name, :description, :category, :path, :image_url, :color, :archetypes, :prerequisite_id, :bonus, :campaign_id, :created_at, :updated_at, :entity_class
+  attributes :id, :name, :description, :category, :path, :image_url, :color, :archetypes, :prerequisite_id, :bonus, :campaign_id, :active, :created_at, :updated_at, :entity_class
   has_many :image_positions, serializer: ImagePositionSerializer
   belongs_to :prerequisite, serializer: SchtickAutocompleteSerializer
 

--- a/app/serializers/weapon_serializer.rb
+++ b/app/serializers/weapon_serializer.rb
@@ -1,5 +1,5 @@
 class WeaponSerializer < ActiveModel::Serializer
-  attributes :id, :name, :image_url, :created_at, :damage, :concealment, :reload_value, :description, :juncture, :category, :mook_bonus, :kachunk, :entity_class, :updated_at
+  attributes :id, :name, :image_url, :created_at, :damage, :concealment, :reload_value, :description, :juncture, :category, :mook_bonus, :kachunk, :active, :entity_class, :updated_at
   has_many :image_positions, serializer: ImagePositionSerializer
 
   def entity_class

--- a/spec/requests/api/v2/campaigns/campaigns_spec.rb
+++ b/spec/requests/api/v2/campaigns/campaigns_spec.rb
@@ -237,6 +237,27 @@ RSpec.describe "Api::V2::Campaigns", type: :request do
         @campaign.reload
         expect(@campaign.image.attached?).to be_truthy
       end
+
+      context "when updating active status" do
+        it "sets active to false" do
+          patch "/api/v2/campaigns/#{@campaign.id}", params: { campaign: { active: false } }, headers: @gamemaster_headers
+          expect(response).to have_http_status(:success)
+          body = JSON.parse(response.body)
+          expect(body["active"]).to eq(false)
+          @campaign.reload
+          expect(@campaign.active).to eq(false)
+        end
+
+        it "sets active to true" do
+          @inactive_campaign.update!(active: false)
+          patch "/api/v2/campaigns/#{@inactive_campaign.id}", params: { campaign: { active: true } }, headers: @gamemaster_headers
+          expect(response).to have_http_status(:success)
+          body = JSON.parse(response.body)
+          expect(body["active"]).to eq(true)
+          @inactive_campaign.reload
+          expect(@inactive_campaign.active).to eq(true)
+        end
+      end
     end
 
     context "when user is admin" do

--- a/spec/requests/api/v2/characters/characters_spec.rb
+++ b/spec/requests/api/v2/characters/characters_spec.rb
@@ -342,6 +342,27 @@ RSpec.describe "Api::V2::Characters", type: :request do
         end
       end
     end
+
+    context "when updating active status" do
+      it "sets active to false" do
+        patch "/api/v2/characters/#{@brick.id}", params: { character: { active: false } }, headers: @headers
+        expect(response).to have_http_status(:success)
+        body = JSON.parse(response.body)
+        expect(body["active"]).to eq(false)
+        @brick.reload
+        expect(@brick.active).to eq(false)
+      end
+
+      it "sets active to true" do
+        @dead_guy.update!(active: false)
+        patch "/api/v2/characters/#{@dead_guy.id}", params: { character: { active: true } }, headers: @headers
+        expect(response).to have_http_status(:success)
+        body = JSON.parse(response.body)
+        expect(body["active"]).to eq(true)
+        @dead_guy.reload
+        expect(@dead_guy.active).to eq(true)
+      end
+    end
   end
 
   describe "GET /show" do

--- a/spec/requests/api/v2/factions/factions_spec.rb
+++ b/spec/requests/api/v2/factions/factions_spec.rb
@@ -228,6 +228,27 @@ RSpec.describe "Api::V2::Factions", type: :request do
       @outlaws.reload
       expect(@outlaws.vehicles).not_to include(@tank)
     end
+
+    context "when updating active status" do
+      it "sets active to false" do
+        patch "/api/v2/factions/#{@dragons.id}", params: { faction: { active: false } }, headers: @headers
+        expect(response).to have_http_status(:success)
+        body = JSON.parse(response.body)
+        expect(body["active"]).to eq(false)
+        @dragons.reload
+        expect(@dragons.active).to eq(false)
+      end
+
+      it "sets active to true" do
+        @inactive_faction.update!(active: false)
+        patch "/api/v2/factions/#{@inactive_faction.id}", params: { faction: { active: true } }, headers: @headers
+        expect(response).to have_http_status(:success)
+        body = JSON.parse(response.body)
+        expect(body["active"]).to eq(true)
+        @inactive_faction.reload
+        expect(@inactive_faction.active).to eq(true)
+      end
+    end
   end
 
   describe "GET /show" do

--- a/spec/requests/api/v2/fights/fights_spec.rb
+++ b/spec/requests/api/v2/fights/fights_spec.rb
@@ -194,6 +194,27 @@ RSpec.describe "Api::V2::Fights", type: :request do
         @brawl.reload
         expect(@brawl.image.attached?).to be_truthy
       end
+
+      context "when updating active status" do
+        it "sets active to false" do
+          patch "/api/v2/fights/#{@brawl.id}", params: { fight: { active: false } }, headers: @gamemaster_headers
+          expect(response).to have_http_status(:ok)
+          body = JSON.parse(response.body)
+          expect(body["active"]).to eq(false)
+          @brawl.reload
+          expect(@brawl.active).to eq(false)
+        end
+
+        it "sets active to true" do
+          @skirmish.update!(active: false)
+          patch "/api/v2/fights/#{@skirmish.id}", params: { fight: { active: true } }, headers: @gamemaster_headers
+          expect(response).to have_http_status(:ok)
+          body = JSON.parse(response.body)
+          expect(body["active"]).to eq(true)
+          @skirmish.reload
+          expect(@skirmish.active).to eq(true)
+        end
+      end
     end
 
     context "when fight does not exist" do

--- a/spec/requests/api/v2/junctures/junctures_spec.rb
+++ b/spec/requests/api/v2/junctures/junctures_spec.rb
@@ -193,6 +193,27 @@ RSpec.describe "Api::V2::Junctures", type: :request do
       @ancient.reload
       expect(@ancient.characters).not_to include(@brick)
     end
+
+    context "when updating active status" do
+      it "sets active to false" do
+        patch "/api/v2/junctures/#{@modern.id}", params: { juncture: { active: false } }, headers: @headers
+        expect(response).to have_http_status(:success)
+        body = JSON.parse(response.body)
+        expect(body["active"]).to eq(false)
+        @modern.reload
+        expect(@modern.active).to eq(false)
+      end
+
+      it "sets active to true" do
+        @inactive_juncture.update!(active: false)
+        patch "/api/v2/junctures/#{@inactive_juncture.id}", params: { juncture: { active: true } }, headers: @headers
+        expect(response).to have_http_status(:success)
+        body = JSON.parse(response.body)
+        expect(body["active"]).to eq(true)
+        @inactive_juncture.reload
+        expect(@inactive_juncture.active).to eq(true)
+      end
+    end
   end
 
   describe "GET /show" do

--- a/spec/requests/api/v2/parties/parties_spec.rb
+++ b/spec/requests/api/v2/parties/parties_spec.rb
@@ -219,6 +219,27 @@ RSpec.describe "Api::V2::Parties", type: :request do
       @ascended_party.reload
       expect(@ascended_party.vehicles).not_to include(@tank)
     end
+
+    context "when updating active status" do
+      it "sets active to false" do
+        patch "/api/v2/parties/#{@dragons_party.id}", params: { party: { active: false } }, headers: @headers
+        expect(response).to have_http_status(:success)
+        body = JSON.parse(response.body)
+        expect(body["active"]).to eq(false)
+        @dragons_party.reload
+        expect(@dragons_party.active).to eq(false)
+      end
+
+      it "sets active to true" do
+        @inactive_team.update!(active: false)
+        patch "/api/v2/parties/#{@inactive_team.id}", params: { party: { active: true } }, headers: @headers
+        expect(response).to have_http_status(:success)
+        body = JSON.parse(response.body)
+        expect(body["active"]).to eq(true)
+        @inactive_team.reload
+        expect(@inactive_team.active).to eq(true)
+      end
+    end
   end
 
   describe "GET /show" do

--- a/spec/requests/api/v2/schticks/schticks_spec.rb
+++ b/spec/requests/api/v2/schticks/schticks_spec.rb
@@ -167,6 +167,27 @@ RSpec.describe "Api::V2::Schticks", type: :request do
       @fireball.reload
       expect(@fireball.image.attached?).to be_truthy
     end
+
+    context "when updating active status" do
+      it "sets active to false" do
+        patch "/api/v2/schticks/#{@fireball.id}", params: { schtick: { active: false } }, headers: @headers
+        expect(response).to have_http_status(:success)
+        body = JSON.parse(response.body)
+        expect(body["active"]).to eq(false)
+        @fireball.reload
+        expect(@fireball.active).to eq(false)
+      end
+
+      it "sets active to true" do
+        @blast.update!(active: false)
+        patch "/api/v2/schticks/#{@blast.id}", params: { schtick: { active: true } }, headers: @headers
+        expect(response).to have_http_status(:success)
+        body = JSON.parse(response.body)
+        expect(body["active"]).to eq(true)
+        @blast.reload
+        expect(@blast.active).to eq(true)
+      end
+    end
   end
 
   describe "GET /show" do

--- a/spec/requests/api/v2/sites/sites_spec.rb
+++ b/spec/requests/api/v2/sites/sites_spec.rb
@@ -161,6 +161,27 @@ RSpec.describe "Api::V2::Sites", type: :request do
       @dragons_hq.reload
       expect(@dragons_hq.image.attached?).to be_truthy
     end
+
+    context "when updating active status" do
+      it "sets active to false" do
+        patch "/api/v2/sites/#{@dragons_hq.id}", params: { site: { active: false } }, headers: @headers
+        expect(response).to have_http_status(:success)
+        body = JSON.parse(response.body)
+        expect(body["active"]).to eq(false)
+        @dragons_hq.reload
+        expect(@dragons_hq.active).to eq(false)
+      end
+
+      it "sets active to true" do
+        @bandit_hideout.update!(active: false)
+        patch "/api/v2/sites/#{@bandit_hideout.id}", params: { site: { active: true } }, headers: @headers
+        expect(response).to have_http_status(:success)
+        body = JSON.parse(response.body)
+        expect(body["active"]).to eq(true)
+        @bandit_hideout.reload
+        expect(@bandit_hideout.active).to eq(true)
+      end
+    end
   end
 
   describe "GET /show" do

--- a/spec/requests/api/v2/vehicles/vehicles_spec.rb
+++ b/spec/requests/api/v2/vehicles/vehicles_spec.rb
@@ -115,6 +115,27 @@ RSpec.describe "Api::V2::Vehicles", type: :request do
       expect(@car.name).to eq("Car")
       expect(@car.juncture_id).to eq(@ancient.id)
     end
+
+    context "when updating active status" do
+      it "sets active to false" do
+        patch "/api/v2/vehicles/#{@car.id}", params: { vehicle: { active: false } }, headers: @headers
+        expect(response).to have_http_status(:success)
+        body = JSON.parse(response.body)
+        expect(body["active"]).to eq(false)
+        @car.reload
+        expect(@car.active).to eq(false)
+      end
+
+      it "sets active to true" do
+        @bike.update!(active: false)
+        patch "/api/v2/vehicles/#{@bike.id}", params: { vehicle: { active: true } }, headers: @headers
+        expect(response).to have_http_status(:success)
+        body = JSON.parse(response.body)
+        expect(body["active"]).to eq(true)
+        @bike.reload
+        expect(@bike.active).to eq(true)
+      end
+    end
   end
 
   describe "GET /show" do

--- a/spec/requests/api/v2/weapons/weapons_spec.rb
+++ b/spec/requests/api/v2/weapons/weapons_spec.rb
@@ -198,6 +198,27 @@ RSpec.describe "Api::V2::Weapons", type: :request do
       expect(@beretta.concealment).to eq(1)
       expect(@beretta.reload_value).to eq(2)
     end
+
+    context "when updating active status" do
+      it "sets active to false" do
+        patch "/api/v2/weapons/#{@beretta.id}", params: { weapon: { active: false } }, headers: @headers
+        expect(response).to have_http_status(:success)
+        body = JSON.parse(response.body)
+        expect(body["active"]).to eq(false)
+        @beretta.reload
+        expect(@beretta.active).to eq(false)
+      end
+
+      it "sets active to true" do
+        @colt.update!(active: false)
+        patch "/api/v2/weapons/#{@colt.id}", params: { weapon: { active: true } }, headers: @headers
+        expect(response).to have_http_status(:success)
+        body = JSON.parse(response.body)
+        expect(body["active"]).to eq(true)
+        @colt.reload
+        expect(@colt.active).to eq(true)
+      end
+    end
   end
 
   describe "GET /show" do


### PR DESCRIPTION
## Summary
Adds backend support for toggling the active field on all entities, complementing the frontend EntityActiveToggle component.

## Changes
### Tests Added
Added comprehensive tests for toggling the `active` field for all 10 entity types:
- Campaigns
- Characters
- Factions
- Fights
- Junctures
- Parties
- Schticks
- Sites
- Vehicles
- Weapons

Each entity now has dedicated tests that:
- Set active to false and verify persistence
- Set active to true and verify persistence
- Confirm both API response and database updates

### Backend Fixes
- Added `active` attribute to WeaponSerializer
- Added `active` attribute to SchtickSerializer
- Updated permitted params in WeaponsController to include `active`
- Updated permitted params in FactionsController to include `active`
- Updated permitted params in SchtickController to include `active`

## Test Results
All 20 new tests are passing (2 tests × 10 entities).

## Related PRs
- Frontend implementation: progressions/shot-client-next#38

🤖 Generated with [Claude Code](https://claude.ai/code)