### PR TITLE
Add fight lifecycle management system

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,7 @@ Rails.application.routes.draw do
         member do
           delete :image, to: "fights#remove_image"
           patch :touch
+          patch :end_fight
         end
         resources :shots, only: [:update, :destroy] do
           member do
@@ -113,6 +114,7 @@ Rails.application.routes.draw do
         member do
           delete :image, to: "campaigns#remove_image"
           patch :set
+          get :current_fight
         end
       end
       resources :users do


### PR DESCRIPTION
## Summary
- Add Fight model methods for lifecycle states (ongoing?, ended?, end_fight!)
- Add campaigns#current_fight endpoint to get active fight for campaign
- Add fights#end_fight endpoint for GM to end fights
- Add WebSocket broadcasts for fight state changes

## Changes
- Fight model now tracks `started_at` and `ended_at` timestamps for lifecycle
- New API endpoints for managing fight states
- Real-time updates broadcast to connected clients

## Test Plan
- [x] Test starting a fight sets started_at timestamp
- [x] Test ending a fight sets ended_at timestamp
- [x] Test current_fight endpoint returns active fight
- [x] Test end_fight endpoint is GM-only
- [x] Test WebSocket broadcasts fire correctly

🤖 Generated with [Claude Code](https://claude.ai/code)