### PR TITLE
fix(fights): allow duplicate party memberships and defer association calls

### DIFF
--- a/db/exports/master_template_export_20250928_184439.sql
+++ b/db/exports/master_template_export_20250928_184439.sql
@@ -4,7 +4,7 @@ INSERT INTO campaigns (
   id, user_id, name, description, is_master_template, active,
   created_at, updated_at
 ) VALUES (
-  'f3c41e34-408a-4a6f-8af0-f7cb45b0355e',
+  'ec087f88-e2b9-4513-a9fd-cb7d989ca581',
   (SELECT id FROM users WHERE email = 'progressions@gmail.com' OR admin = true ORDER BY created_at LIMIT 1),
   'Master Template Campaign',
   NULL,

--- a/db/migrate/20250928172151_remove_unique_index_from_memberships.rb
+++ b/db/migrate/20250928172151_remove_unique_index_from_memberships.rb
@@ -1,0 +1,22 @@
+class RemoveUniqueIndexFromMemberships < ActiveRecord::Migration[8.0]
+  INDEX_NAME = "memberships_party_id_character_id_index"
+
+  def up
+    execute <<~SQL
+      ALTER TABLE memberships
+      DROP CONSTRAINT IF EXISTS #{INDEX_NAME};
+    SQL
+
+    if index_exists?(:memberships, [:party_id, :character_id], name: INDEX_NAME)
+      remove_index :memberships, column: [:party_id, :character_id], name: INDEX_NAME
+    end
+  end
+
+  def down
+    execute <<~SQL
+      ALTER TABLE memberships
+      ADD CONSTRAINT #{INDEX_NAME}
+      UNIQUE (party_id, character_id);
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_06_201529) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_28_172151) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -58,6 +58,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_06_201529) do
     t.datetime "updated_at", null: false
     t.index ["character_id"], name: "index_attunements_on_character_id"
     t.index ["site_id"], name: "index_attunements_on_site_id"
+    t.unique_constraint ["character_id", "site_id"], name: "attunements_character_id_site_id_index"
   end
 
   create_table "campaign_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -288,6 +289,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_06_201529) do
     t.index ["character_id"], name: "index_memberships_on_character_id"
     t.index ["party_id"], name: "index_memberships_on_party_id"
     t.index ["vehicle_id"], name: "index_memberships_on_vehicle_id"
+    t.unique_constraint ["party_id", "vehicle_id"], name: "memberships_party_id_vehicle_id_index"
   end
 
   create_table "onboarding_progresses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Summary
- Allow duplicate party memberships in fight creation
- Defer association method calls when creating fights to avoid errors
- Update master template database export

## Test plan
- [ ] Verify fights can be created with duplicate party memberships
- [ ] Test fight creation with proper association handling
- [ ] Validate database export updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)